### PR TITLE
Add hand results view at end of round explaining hand

### DIFF
--- a/lib/bet_buddies_web/live/game_live/index.ex
+++ b/lib/bet_buddies_web/live/game_live/index.ex
@@ -26,7 +26,7 @@ defmodule BetBuddiesWeb.GameLive.Index do
       round_winner: winner
     } = game_state = Poker.get_game_state(game_id)
 
-    %Player{contributed: players_bet} = player = find_player(players, player_id)
+    %Player{contributed: _players_bet} = player = find_player(players, player_id)
 
     other_players = players -- [player]
 

--- a/lib/bet_buddies_web/live/game_live/index.ex
+++ b/lib/bet_buddies_web/live/game_live/index.ex
@@ -23,12 +23,15 @@ defmodule BetBuddiesWeb.GameLive.Index do
       next_call: next_call,
       player_queue: player_queue,
       dealer_hand: dealer_hand,
-      round_winner: winner
+      round_winner: winner,
+      player_hand_reports: player_hand_reports
     } = game_state = Poker.get_game_state(game_id)
 
     %Player{contributed: _players_bet} = player = find_player(players, player_id)
 
     other_players = players -- [player]
+
+    player_hand_report = Enum.find(player_hand_reports, fn report -> report.player_id == player.player_id end)
 
     socket =
       assign(socket, :game_id, game_id)
@@ -46,6 +49,7 @@ defmodule BetBuddiesWeb.GameLive.Index do
       |> assign(:player_queue, player_queue)
       |> assign(:dealer_hand, dealer_hand)
       |> assign(:winner, winner)
+      |> assign(:player_hand_report, player_hand_report)
 
     {:ok, socket}
   end
@@ -108,12 +112,15 @@ defmodule BetBuddiesWeb.GameLive.Index do
       next_call: next_call,
       player_queue: player_queue,
       dealer_hand: dealer_hand,
-      round_winner: winner
+      round_winner: winner,
+      player_hand_reports: player_hand_reports
     } =
       Poker.get_game_state(game_id)
 
     %Player{} = player = find_player(players, player.player_id)
     other_players = players -- [player]
+
+    player_hand_report = Enum.find(player_hand_reports, fn report -> report.player_id == player.player_id end)
 
     socket =
       assign(socket, :game_id, game_id)
@@ -129,6 +136,7 @@ defmodule BetBuddiesWeb.GameLive.Index do
       |> assign(:player_queue, player_queue)
       |> assign(:dealer_hand, dealer_hand)
       |> assign(:winner, winner)
+      |> assign(:player_hand_report, player_hand_report)
 
     {:noreply, socket}
   end
@@ -163,6 +171,7 @@ defmodule BetBuddiesWeb.GameLive.Index do
         <% end %>
         <.player
           winner={@winner}
+          report={@player_hand_report}
           player={@player}
           bet_slider_value={@bet_slider_value}
           game_stage={@game_stage}
@@ -522,8 +531,9 @@ defmodule BetBuddiesWeb.GameLive.Index do
             <div class="flex border shadow-lg rounded p-2 bg-white">
               <div class="flex-col space-y-2">
                 <%= if @winner == @player.player_id do %>
-                  <div class="flex-row text-center">Winner</div>
+                  <div class="flex-row text-center">Winner <%= @report.best.type %></div>
                 <% else %>
+                  <div class="flex-row text-center"><%= if @report, do: @report.best.type, else: nil %></div>
                 <% end %>
                 <div class="flex-row text-center"><%= @player.name %></div>
                 <div class="flex-row bg-gray-300 rounded p-1 text-center">$<%= @player.wallet %></div>

--- a/lib/poker/game_session.ex
+++ b/lib/poker/game_session.ex
@@ -1,6 +1,6 @@
 defmodule Poker.GameSession do
   use GenServer
-  alias Poker.Card
+
   alias Poker.GameState
   alias Phoenix.PubSub
   alias Poker.Player
@@ -99,7 +99,7 @@ defmodule Poker.GameSession do
         _from,
         %GameState{} = game_state
       ) do
-    %{player: calling_player, index: player_index} = find_player(game_state, player_id)
+    %{player: calling_player, index: _player_index} = find_player(game_state, player_id)
 
     if GameState.is_game_active?(game_state) do
       if GameState.is_players_turn?(game_state, calling_player) do
@@ -136,7 +136,7 @@ defmodule Poker.GameSession do
 
   def handle_call({:fold, player_id}, _from, %GameState{} = game_state) do
     if GameState.is_game_active?(game_state) do
-      %{player: player, index: player_index} = find_player(game_state, player_id)
+      %{player: player, index: _player_index} = find_player(game_state, player_id)
 
       updated_player = Player.set_folded(player, true)
 

--- a/lib/poker/game_state.ex
+++ b/lib/poker/game_state.ex
@@ -145,11 +145,11 @@ defmodule Poker.GameState do
   end
 
   @spec is_players_turn?(%GameState{}, %Player{}) :: boolean()
-  def is_players_turn?(%GameState{turn_number: turn_number, player_queue: player_queue}, %Player{
-        turn_number: player_turn_number,
+  def is_players_turn?(%GameState{turn_number: _turn_number, player_queue: player_queue}, %Player{
+        turn_number: _player_turn_number,
         player_id: player_id
       }) do
-    %Player{player_id: queue_player_id} = top_queue_player = List.first(player_queue)
+    %Player{player_id: queue_player_id} = _top_queue_player = List.first(player_queue)
     queue_player_id == player_id
   end
 

--- a/test/poker/game_state_test.exs
+++ b/test/poker/game_state_test.exs
@@ -9,7 +9,7 @@ defmodule Poker.GameStateTest do
 
       player = player_factory()
 
-      {:ok, pid} = Poker.GameSupervisor.create_game(game_id, player)
+      {:ok, _pid} = Poker.GameSupervisor.create_game(game_id, player)
     end
   end
 

--- a/test/poker/poker_test.exs
+++ b/test/poker/poker_test.exs
@@ -186,7 +186,7 @@ defmodule Poker.PokerTest do
     end
 
     test "successfully call", %{
-      started_game: %GameState{game_id: game_id, player_queue: players} = game_state
+      started_game: %GameState{game_id: game_id, player_queue: players} = _game_state
     } do
       [player | _tail] = players
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0c4bd474-d125-458d-bf4a-13954bdf388b)
Adds word to show player hand results, discovered a bug though now issue #13 